### PR TITLE
Feat/카풀완료 버튼 테스트 및 여러페이지 기능, UI 수정

### DIFF
--- a/app/(tabs)/chat_list.tsx
+++ b/app/(tabs)/chat_list.tsx
@@ -252,7 +252,7 @@ export default function ChatList() {
                       ) : // 일반 참여자 버튼
                       now < startTime ? (
                         <BasicButton
-                          icon="exit"
+                          icon="trash"
                           title="카풀퇴장"
                           onPress={() => handleDeleteOrLeave(v, false)}
                           color="#e74c3c"

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -22,7 +22,6 @@ type Party = {
 
 const getMySchedule = async () => {
   const token = await authCode.get();
-  console.log("🏠 토큰 체크:", token);
   if (!token) return null;
 
   const res = await fetchInstance(true).get("/api/party/my-parties");
@@ -50,7 +49,6 @@ export default function HomeScreen() {
     useCallback(() => {
       const checkToken = async () => {
         const token = await authCode.get();
-        console.log("📌 Home 진입 - 현재 토큰:", token);
         setIsLoggedIn(!!token);
         setAuthChanged((prev) => prev + 1);
       };
@@ -80,7 +78,7 @@ export default function HomeScreen() {
 
   return (
     <Container>
-      <ScheduleBox onPress={handleSchedulePress}>
+      <ScheduleBox onPress={handleSchedulePress} disabled={!!isLoggedIn && !schedule}>
         {isLoggedIn === null || (isLoggedIn && isPending) ? (
           <BoxText>불러오는 중...</BoxText>
         ) : !isLoggedIn ? (

--- a/app/(tabs)/my_page.tsx
+++ b/app/(tabs)/my_page.tsx
@@ -1,6 +1,6 @@
 import { Ionicons, MaterialIcons } from "@expo/vector-icons";
-import { useRouter } from "expo-router";
-import { useEffect, useState } from "react";
+import { useFocusEffect, useRouter } from "expo-router";
+import { useCallback, useState } from "react";
 import {
   Alert,
   Dimensions,
@@ -45,36 +45,38 @@ export default function MyPage() {
   const [modalNickname, setModalNickname] = useState("");
   const [modalPassword, setModalPassword] = useState("");
 
-  // 사용자 정보 가져오기
-  useEffect(() => {
-    const checkTokenAndFetchUser = async () => {
-      const token = await authCode.get();
-      if (!token) {
-        setIsLoggedIn(false);
-        return;
-      }
+  // 🔹 페이지 포커스될 때마다 토큰 체크 및 유저 정보 갱신
+  useFocusEffect(
+    useCallback(() => {
+      const checkTokenAndFetchUser = async () => {
+        const token = await authCode.get();
+        if (!token) {
+          setIsLoggedIn(false);
+          return;
+        }
 
-      setIsLoggedIn(true);
+        setIsLoggedIn(true);
 
-      try {
-        const profileRes = await fetchInstance(true).get("/api/member/me");
-        const nickname = profileRes.data?.nickname ?? "닉네임 없음";
-        const email = profileRes.data?.email ?? null;
-        const totalSavedAmount = profileRes.data?.totalSavedAmount ?? 0;
+        try {
+          const profileRes = await fetchInstance(true).get("/api/member/me");
+          const nickname = profileRes.data?.nickname ?? "닉네임 없음";
+          const email = profileRes.data?.email ?? null;
+          const totalSavedAmount = profileRes.data?.totalSavedAmount ?? 0;
 
-        setNickname(nickname);
-        setInitialNickname(nickname);
-        setEmail(email);
-        setSavedAmount(totalSavedAmount); // 여기서 반영
-      } catch (error: unknown) {
-        console.error("❌ 사용자 정보 불러오기 실패:", error);
-        setIsLoggedIn(false);
-        Alert.alert("⚠️ 오류", "회원 정보를 불러오지 못했습니다.");
-      }
-    };
+          setNickname(nickname);
+          setInitialNickname(nickname);
+          setEmail(email);
+          setSavedAmount(totalSavedAmount);
+        } catch (error: unknown) {
+          console.error("❌ 사용자 정보 불러오기 실패:", error);
+          setIsLoggedIn(false);
+          Alert.alert("⚠️ 오류", "회원 정보를 불러오지 못했습니다.");
+        }
+      };
 
-    checkTokenAndFetchUser();
-  }, []);
+      checkTokenAndFetchUser();
+    }, []),
+  );
 
   const openModal = () => {
     setModalNickname("");
@@ -100,7 +102,6 @@ export default function MyPage() {
         setInitialNickname(res.data.nickname);
       }
 
-      // 업데이트 후 금액도 다시 가져오기
       if (res.data.totalSavedAmount !== undefined) {
         setSavedAmount(res.data.totalSavedAmount);
       }
@@ -179,13 +180,24 @@ export default function MyPage() {
         <TopContainer />
         <AbsoluteTopOverlay>
           <TopHalf>
-            <ProfileImage source={defaultProfile} />
-            <LoginGuideText>로그인이 필요합니다.</LoginGuideText>
+            <TopRow>
+              <TextContainer>
+                <NicknameText>닉네임</NicknameText>
+                <EmailBox>
+                  <EmailText>로그인이 필요합니다.</EmailText>
+                </EmailBox>
+              </TextContainer>
+              <ProfileImage source={defaultProfile} />
+            </TopRow>
+          </TopHalf>
+        </AbsoluteTopOverlay>
+        <OverlapBox>
+          <Row>
             <LoginGuideButton onPress={() => router.push("/signin")}>
               <LoginGuideText>로그인 하러 가기 &gt;</LoginGuideText>
             </LoginGuideButton>
-          </TopHalf>
-        </AbsoluteTopOverlay>
+          </Row>
+        </OverlapBox>
         <BottomContainer />
       </Container>
     );
@@ -207,8 +219,6 @@ export default function MyPage() {
           </TopRow>
         </TopHalf>
       </AbsoluteTopOverlay>
-
-      {/* 저장 금액 표시 */}
       <OverlapBox>
         <Row>
           <Ionicons name="wallet" size={30} color="#4a90e2" />
@@ -218,24 +228,17 @@ export default function MyPage() {
 
       <BottomContainer>
         <BottomHalf>
-          {/* 정보 변경 버튼 */}
           <ActionButton bgColor="#4a90e2" onPress={openModal}>
             <ActionButtonText>정보 변경</ActionButtonText>
           </ActionButton>
-
-          {/* 로그아웃 버튼 */}
           <ActionButton bgColor="#f1c40f" onPress={handleLogout}>
             <ActionButtonText>로그아웃</ActionButtonText>
           </ActionButton>
-
-          {/* 계정 삭제 버튼 */}
           <ActionButton bgColor="#e74c3c" onPress={handleDeleteAccount}>
             <ActionButtonText>계정 삭제하기</ActionButtonText>
           </ActionButton>
         </BottomHalf>
       </BottomContainer>
-
-      {/* 정보 변경 모달 */}
       <Modal
         visible={isModalVisible}
         animationType="slide"
@@ -272,7 +275,6 @@ export default function MyPage() {
   );
 }
 
-/* ------------------- Styled Components ------------------- */
 const { width } = Dimensions.get("window");
 
 const Container = styled(View)({
@@ -386,39 +388,41 @@ const ActionButton = styled(TouchableOpacity)<{ bgColor?: string }>({
   shadowOffset: { width: 0, height: 4 },
   shadowOpacity: 0.3,
   shadowRadius: 4,
-  elevation: 6,
+  elevation: 3,
 });
 
 const ActionButtonText = styled(Text)({
   fontSize: 16,
   fontWeight: "bold",
-  color: "#fff",
+  color: "#333",
 });
 
 const Row = styled(View)({
   flexDirection: "row",
   alignItems: "center",
-  marginBottom: 20,
-  marginTop: 10,
+  marginBottom: 2,
 });
 
 const InfoText = styled(Text)({
   fontSize: 20,
-  color: "#4a4a4a",
-  marginLeft: 8,
+  color: "#333",
+  marginLeft: 7,
 });
 
 const LoginGuideButton = styled(TouchableOpacity)({
-  backgroundColor: "#4a90e2",
+  width: 380,
+  height: 100,
+  backgroundColor: "#ffffff",
   paddingVertical: 12,
   paddingHorizontal: 24,
   borderRadius: 25,
-  marginTop: 16,
+  alignItems: "center",
+  justifyContent: "center",
 });
 
 const LoginGuideText = styled(Text)({
-  color: "white",
-  fontSize: 16,
+  color: "#333",
+  fontSize: 22,
   fontWeight: "bold",
 });
 

--- a/app/(tabs)/my_page.tsx
+++ b/app/(tabs)/my_page.tsx
@@ -1,4 +1,4 @@
-import { Ionicons, MaterialIcons } from "@expo/vector-icons";
+import { Ionicons } from "@expo/vector-icons";
 import { useFocusEffect, useRouter } from "expo-router";
 import { useCallback, useState } from "react";
 import {
@@ -40,11 +40,11 @@ export default function MyPage() {
   const [email, setEmail] = useState<string | null>("example@email.com");
   const [isModalVisible, setIsModalVisible] = useState(false);
 
-  // 모달 전용 상태
   const [modalNickname, setModalNickname] = useState("");
   const [modalPassword, setModalPassword] = useState("");
 
-  // 🔹 페이지 포커스될 때마다 토큰 체크 및 유저 정보 갱신
+  const { width } = Dimensions.get("window");
+
   useFocusEffect(
     useCallback(() => {
       const checkTokenAndFetchUser = async () => {
@@ -176,7 +176,7 @@ export default function MyPage() {
   if (!isLoggedIn) {
     return (
       <Container>
-        <TopContainer />
+        <TopContainer width={width} />
         <AbsoluteTopOverlay>
           <TopHalf>
             <TopRow>
@@ -204,7 +204,7 @@ export default function MyPage() {
 
   return (
     <Container>
-      <TopContainer />
+      <TopContainer width={width} />
       <AbsoluteTopOverlay>
         <TopHalf>
           <TopRow>
@@ -238,6 +238,7 @@ export default function MyPage() {
           </ActionButton>
         </BottomHalf>
       </BottomContainer>
+
       <Modal
         visible={isModalVisible}
         animationType="slide"
@@ -274,8 +275,7 @@ export default function MyPage() {
   );
 }
 
-const { width } = Dimensions.get("window");
-
+// 스타일 정의
 const Container = styled(View)({
   flex: 1,
   backgroundColor: "#f0f0f0",
@@ -283,7 +283,7 @@ const Container = styled(View)({
   justifyContent: "flex-start",
 });
 
-const TopContainer = styled(View)({
+const TopContainer = styled(View)<{ width: number }>(({ width }) => ({
   width: width * 1.6,
   height: width * 1.6,
   borderRadius: (width * 1.6) / 2,
@@ -291,7 +291,7 @@ const TopContainer = styled(View)({
   top: -width * 0.3,
   position: "relative",
   backgroundColor: "rgb(148, 200, 230)",
-});
+}));
 
 const AbsoluteTopOverlay = styled(View)({
   position: "absolute",
@@ -311,7 +311,7 @@ const BottomHalf = styled(View)({
   flexDirection: "row",
   justifyContent: "space-around",
   alignItems: "center",
-  marginTop: 130,
+  marginTop: 115,
 });
 
 const TopRow = styled(View)({
@@ -339,7 +339,6 @@ const EmailText = styled(Text)({
 });
 
 const BottomContainer = styled(View)({
-  display: "flex",
   flexDirection: "row",
   gap: 12,
   marginBottom: 10,
@@ -347,8 +346,9 @@ const BottomContainer = styled(View)({
 
 const OverlapBox = styled(View)({
   position: "absolute",
-  top: "34%",
-  width: "340px",
+  top: "52%",
+  height: 100,
+  width: 370,
   backgroundColor: "#ffffff",
   borderRadius: 20,
   zIndex: 10,
@@ -358,7 +358,7 @@ const OverlapBox = styled(View)({
   shadowOffset: { width: 0, height: 4 },
   shadowOpacity: 0.25,
   shadowRadius: 6,
-  elevation: 8,
+  elevation: 6,
 });
 
 const ProfileImage = styled(Image)({
@@ -375,6 +375,10 @@ const NicknameText = styled(Text)({
 });
 
 const ActionButton = styled(TouchableOpacity)<{ bgColor?: string }>(({ bgColor }) => ({
+  width: 120,
+  height: 50,
+  alignItems: "center",
+  justifyContent: "center",
   paddingVertical: 8,
   paddingHorizontal: 12,
   borderRadius: 15,
@@ -383,7 +387,7 @@ const ActionButton = styled(TouchableOpacity)<{ bgColor?: string }>(({ bgColor }
   shadowOffset: { width: 0, height: 4 },
   shadowOpacity: 0.3,
   shadowRadius: 4,
-  elevation: 3,
+  elevation: 2,
 }));
 
 const ActionButtonText = styled(Text)({

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,31 +1,32 @@
 import { getAnalytics, logScreenView } from "@react-native-firebase/analytics";
 import { getApp } from "@react-native-firebase/app";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Stack, useGlobalSearchParams, usePathname } from "expo-router";
+import { Stack, StackScreenProps } from "expo-router";
 import React, { useEffect, useState } from "react";
-
-import LoadingScreen from "./loadingpage";
 
 const queryClient = new QueryClient();
 
+type ChatPageParams = {
+  startPlace?: string;
+  endPlace?: string;
+};
+
 export default function RootLayout() {
   const [isLoading, setIsLoading] = useState(true);
-  const pathname = usePathname();
-  const params = useGlobalSearchParams();
   const app = getApp();
   const analytics = getAnalytics(app);
 
-  // 페이지 방문 시 애널리틱스에 기록
+  // 페이지 방문 시 애널리틱스 기록
   useEffect(() => {
     logScreenView(analytics, {
-      screen_name: pathname,
-      screen_class: pathname,
-      params: params,
+      screen_name: "RootLayout",
+      screen_class: "RootLayout",
+      params: {},
     });
-  }, [pathname, params, analytics]);
+  }, [analytics]);
 
   useEffect(() => {
-    const timer = setTimeout(() => setIsLoading(false), 5000); // 5초
+    const timer = setTimeout(() => setIsLoading(false), 5000);
     return () => clearTimeout(timer);
   }, []);
 
@@ -40,6 +41,22 @@ export default function RootLayout() {
         <Stack.Screen name="carpool/recruit" options={{ headerShown: false }} />
         <Stack.Screen name="carpool/recheck" options={{ headerShown: false }} />
         <Stack.Screen name="carpool/find_track" options={{ headerShown: false }} />
+
+        <Stack.Screen
+          name="chatpage"
+          options={({ route }: StackScreenProps<{ chatpage: ChatPageParams }>["route"]) => {
+            const start = route?.params?.startPlace || "출발지";
+            const end = route?.params?.endPlace || "목적지";
+            return {
+              title: `${start} → ${end}`,
+              headerTintColor: "#000000",
+              headerStyle: { backgroundColor: "#f2f2f2" },
+              headerTitleAlign: "left",
+              headerTitleStyle: { fontSize: 15 },
+              contentStyle: { backgroundColor: "#fff" },
+            };
+          }}
+        />
       </Stack>
     </QueryClientProvider>
   );

--- a/app/carpool/edit.tsx
+++ b/app/carpool/edit.tsx
@@ -59,7 +59,13 @@ export default function Edit() {
             destination={destination}
           />
           <ExtraSetting />
-          <BasicButton title="삭제하기" icon="trash" isToRight={true} onPress={handleDeleteParty} />
+          <BasicButton
+            title="삭제하기"
+            icon="trash"
+            color="#FF0000"
+            isToRight={true}
+            onPress={handleDeleteParty}
+          />
           <CircleButton
             icon="checkmark"
             onPress={() =>


### PR DESCRIPTION
변경 사항

**메인페이지**
 - 카풀 일정이 없을때 일정 버튼 비활성화
 - 비로그인시 일정 창 누르면 로그인 화면으로 이동

**채팅페이지**
 - 채팅 페이지 상단에 출발지 -> 목적지 노출(채팅방 이름 효과)
 - 내가 보낸 채팅 말풍선 색상 변경
 - 파티 나가면 구독 끊기게 수정(FCM 알림 안오게)

**마이페이지**
 - 아꼈습니다 상자 텍스트 위치 조절
 - 하단 버튼 3종 텍스트 색상, 그림자 강도 변경
 - 비로그인시 UI 수정
 - 마이페이지 진입시마다 /me api호출


**참여중인카풀 페이지**
 - 호스트면 카풀시간 후 설정변경 대신 삭제하기 버튼으로 변경
 - 호스트아니면 카풀시간 전 = 카풀퇴장, 카풀시간 후 = 삭제하기로 UI변경  
 - 삭제, 퇴장버튼 누르면 재확인 모달
