### PR TITLE
Fix/배포 준비

### DIFF
--- a/app/(tabs)/chat_list.tsx
+++ b/app/(tabs)/chat_list.tsx
@@ -3,7 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { useRouter } from "expo-router";
 import { useEffect, useRef, useState } from "react";
-import { Alert, Animated, ScrollView, Text } from "react-native";
+import { Alert, ScrollView, Text } from "react-native";
 import styled from "styled-components/native";
 
 import usePartyStore from "@/entities/carpool/store/usePartyStore";
@@ -15,92 +15,61 @@ import PartyCard from "@/entities/common/components/party_card";
 import { fetchInstance } from "@/entities/common/util/axios_instance";
 import { Colors, FontSizes } from "@/entities/common/util/style_var";
 
-// Raw -> Party 변환
+interface AxiosErrorResponse {
+  response?: {
+    data?: {
+      message?: string;
+    };
+  };
+}
+
+const isAxiosError = (err: unknown): err is AxiosErrorResponse => {
+  return typeof err === "object" && err !== null && "response" in err;
+};
+
 const mapRawPartyWithSavings = (raw: RawPartyResponse): PartyResponse => ({
   ...mapRawParty(raw),
   savingsCalculated: raw.savingsCalculated ?? false,
 });
 
-// 내 파티 조회
 const fetchChatList = async (): Promise<PartyResponse[]> => {
   try {
     const res = await fetchInstance(true).get<RawPartyResponse[]>("/api/party/my-parties");
     return res.data.map(mapRawPartyWithSavings);
   } catch (err) {
+    console.error(err);
     return [];
   }
 };
 
-// 날짜별 그룹화
 const groupByDate = (parties: PartyResponse[]) =>
-  parties.reduce(
-    (acc, party) => {
-      const date = format(new Date(party.startDateTime), "yyyy-MM-dd");
-      if (!acc[date]) acc[date] = [];
-      acc[date].push(party);
-      return acc;
-    },
-    {} as Record<string, PartyResponse[]>,
-  );
-
-// 강조 카드 애니메이션
-const HighlightedCard = ({
-  isHighlighted,
-  children,
-}: {
-  isHighlighted: boolean;
-  children: React.ReactNode;
-}) => {
-  const borderColorAnim = useRef(new Animated.Value(0)).current;
-
-  useEffect(() => {
-    if (isHighlighted) {
-      Animated.sequence([
-        Animated.timing(borderColorAnim, { toValue: 1, duration: 1000, useNativeDriver: false }),
-        Animated.timing(borderColorAnim, { toValue: 0, duration: 1000, useNativeDriver: false }),
-      ]).start();
-    }
-  }, [isHighlighted, borderColorAnim]);
-
-  const borderColor = borderColorAnim.interpolate({
-    inputRange: [0, 1],
-    outputRange: ["transparent", "blue"],
-  });
-
-  return (
-    <Animated.View style={{ borderColor, borderWidth: 2, borderRadius: 22 }}>
-      {children}
-    </Animated.View>
-  );
-};
+  parties.reduce((acc: Record<string, PartyResponse[]>, party) => {
+    const date = format(new Date(party.startDateTime), "yyyy-MM-dd");
+    if (!acc[date]) acc[date] = [];
+    acc[date].push(party);
+    return acc;
+  }, {});
 
 export default function ChatList() {
   const router = useRouter();
   const queryClient = useQueryClient();
-  const { isLoading, data: chatRoomsData } = useQuery<PartyResponse[]>({
+  const scrollViewRef = useRef<ScrollView>(null);
+
+  const { isLoading, data: chatRoomsData } = useQuery({
     queryKey: ["parties", "my"],
     queryFn: fetchChatList,
   });
-  const [isSubLoading, setIsSubLoading] = useState(false);
 
   const [chatRooms, setChatRooms] = useState<PartyResponse[]>([]);
-  const partyId = usePartyStore((state) => state.partyId);
   const [userId, setUserId] = useState<number | null>(null);
-  const scrollViewRef = useRef<ScrollView>(null);
-  const setPartyStore = usePartyStore((state) => state.setPartyState);
-  const stompClients = useRef<Record<number, Client>>({}); // roomId -> STOMP client
 
-  const refreshChatList = () => {
-    queryClient.invalidateQueries({ queryKey: ["parties", "my"] });
-  };
+  const setPartyStore = usePartyStore((state) => state.setPartyState);
+  const stompClients = useRef<Record<number, Client>>({});
 
   useEffect(() => {
     if (chatRoomsData) setChatRooms(chatRoomsData);
   }, [chatRoomsData]);
 
-  const groupedChatRooms = chatRooms ? groupByDate(chatRooms) : {};
-
-  // 내 정보 가져오기
   useEffect(() => {
     fetchInstance(true)
       .get("/api/member/me")
@@ -108,76 +77,43 @@ export default function ChatList() {
       .catch(() => setUserId(-1));
   }, []);
 
-  // 특정 파티 스크롤
-  useEffect(() => {
-    if (chatRooms && partyId) {
-      const targetIndex = chatRooms.findIndex((party) => party.id === partyId);
-      if (targetIndex !== -1 && scrollViewRef.current) {
-        scrollViewRef.current.scrollTo({ y: targetIndex * 180, animated: true });
-      }
-    }
-  }, [chatRooms, partyId]);
-
-  // 카풀 완료
-  const handleCompleteCarpool = async (v: PartyResponse) => {
-    try {
-      setIsSubLoading(true);
-      await fetchInstance(true)
-        .post(`/api/party/${v.id}/savings`)
-        .then(() => {
-          Alert.alert("✅ 카풀이 성공적으로 완료되었습니다.");
-          setChatRooms((prev) =>
-            prev.map((p) => (p.id === v.id ? { ...p, savingsCalculated: true } : p)),
-          );
-          setIsSubLoading(false);
-        })
-        .catch((err) => {
-          Alert.alert("실패", err.response?.data?.message || "알 수 없는 오류");
-          setIsSubLoading(false);
-        });
-    } catch (err) {}
+  const refreshChatList = () => {
+    queryClient.invalidateQueries({ queryKey: ["parties", "my"] });
   };
 
-  const handleDeleteOrLeave = async (party: PartyResponse, isHost: boolean) => {
-    const now = new Date();
-    const startTime = new Date(party.startDateTime);
-    const startPlus1Min = new Date(startTime.getTime() + 60_000);
+  const unsubscribeStomp = (partyId: number) => {
+    const client = stompClients.current[partyId];
+    if (client && client.connected) {
+      client.deactivate();
+      delete stompClients.current[partyId];
+    }
+  };
 
-    // 일반 참여자가 종료된 카풀에서 삭제 버튼을 누르면 메시지 변경
-    const alertMessage = isHost
-      ? "정말로 파티를 삭제하시겠습니까?"
-      : now >= startPlus1Min
-        ? "종료된 카풀입니다. 삭제하시겠습니까?"
-        : "정말로 카풀에서 퇴장하시겠습니까?";
-
-    const actionText = isHost || now >= startPlus1Min ? "삭제" : "퇴장";
-
-    Alert.alert(`⚠️ ${actionText}`, alertMessage, [
+  const handleLeave = (party: PartyResponse) => {
+    Alert.alert("⚠️ 퇴장 확인", "정말 퇴장하시겠습니까?", [
       { text: "취소", style: "cancel" },
       {
-        text: actionText,
+        text: "퇴장",
         style: "destructive",
         onPress: async () => {
           try {
-            // FCM 알림 방지
             await fetchInstance(true).post(`/api/party/${party.id}/leave`, { preventFcm: true });
 
-            // STOMP 구독 해제
-            const client = stompClients.current[party.id];
-            if (client && client.connected) {
-              client.deactivate();
-              delete stompClients.current[party.id];
-            }
+            unsubscribeStomp(party.id);
 
-            Alert.alert(isHost ? "✅ 파티가 삭제되었습니다." : "✅ 카풀 기록이 삭제되었습니다.");
+            Alert.alert("완료", "정상적으로 퇴장했습니다.");
             refreshChatList();
-          } catch (err) {}
+          } catch (err: unknown) {
+            const message = isAxiosError(err) ? err.response?.data?.message : "알 수 없는 오류";
+
+            Alert.alert("오류", message ?? "알 수 없는 오류");
+          }
         },
       },
     ]);
   };
 
-  if ((userId ?? -1) < 0 || isLoading || !chatRooms || chatRooms.length === 0) {
+  if ((userId ?? -1) < 0 || isLoading || chatRooms.length === 0) {
     return (
       <Container>
         <EmptyState>
@@ -193,9 +129,10 @@ export default function ChatList() {
     );
   }
 
+  const groupedChatRooms = groupByDate(chatRooms);
+
   return (
     <Container ref={scrollViewRef} onScrollToTop={refreshChatList}>
-      {isSubLoading && <LoadingIndicator />}
       {Object.entries(groupedChatRooms).map(([date, parties]) => (
         <DateGroup key={date}>
           <RowContainer justifyContent="flex-start">
@@ -210,32 +147,35 @@ export default function ChatList() {
           {parties.map((v) => {
             const isHost = userId === v.hostMemberId;
             const now = new Date();
-            const startTime = new Date(v.startDateTime);
-            const startPlus1Min = new Date(startTime.getTime() + 60_000);
+            const start = new Date(v.startDateTime);
+            const isActive = start > now;
 
             return (
-              <HighlightedCard key={v.id} isHighlighted={v.id === partyId}>
-                <PartyCard
-                  showTitle={true}
-                  when2go={v.startDateTime}
-                  departure={v.startPlace}
-                  destination={v.endPlace}
-                  maxMembers={v.maxParticipantCount}
-                  curMembers={v.currentParticipantCount}
-                  estimatedFare={v.estimatedFare}
-                  options={{
-                    sameGenderOnly: v.sameGenderOnly,
-                    costShareBeforeDropOff: v.costShareBeforeDropOff,
-                    quietMode: v.quietMode,
-                    destinationChangeIn5Minutes: v.destinationChangeIn5Minutes,
-                  }}
-                  buttons={
-                    <RowContainer justifyContent="flex-end" gap={7}>
-                      {isHost ? (
-                        now < startTime ? (
+              <PartyCard
+                key={v.id}
+                isActive={isActive}
+                showTitle={true}
+                when2go={v.startDateTime}
+                departure={v.startPlace}
+                destination={v.endPlace}
+                maxMembers={v.maxParticipantCount}
+                curMembers={v.currentParticipantCount}
+                estimatedFare={v.estimatedFare}
+                options={{
+                  sameGenderOnly: v.sameGenderOnly,
+                  costShareBeforeDropOff: v.costShareBeforeDropOff,
+                  quietMode: v.quietMode,
+                  destinationChangeIn5Minutes: v.destinationChangeIn5Minutes,
+                }}
+                buttons={
+                  <RowContainer justifyContent="flex-end" gap={18}>
+                    {isHost && (
+                      <>
+                        {now < start && (
                           <BasicButton
-                            icon="gearshape"
-                            title="설정 변경"
+                            icon="settings"
+                            title="설정변경"
+                            color={Colors.main}
                             onPress={() => {
                               setPartyStore({
                                 partyId: v.id,
@@ -255,58 +195,36 @@ export default function ChatList() {
                               });
                               router.push("/carpool/edit");
                             }}
-                            color={Colors.main}
                           />
-                        ) : now >= startPlus1Min ? (
-                          <>
-                            {!v.savingsCalculated && (
-                              <BasicButton
-                                icon="checkmark"
-                                title="카풀 완료"
-                                onPress={() => handleCompleteCarpool(v)}
-                                color="#18c617"
-                              />
-                            )}
-                            <BasicButton
-                              icon="trash"
-                              title="삭제하기"
-                              onPress={() => handleDeleteOrLeave(v, true)}
-                              color="#e74c3c"
-                            />
-                          </>
-                        ) : null
-                      ) : now < startTime ? (
-                        <BasicButton
-                          icon="trash"
-                          title="카풀퇴장"
-                          onPress={() => handleDeleteOrLeave(v, false)}
-                          color="#e74c3c"
-                        />
-                      ) : now >= startPlus1Min ? (
-                        <BasicButton
-                          icon="trash"
-                          title="삭제하기"
-                          onPress={() => handleDeleteOrLeave(v, false)}
-                          color="#e74c3c"
-                        />
-                      ) : null}
+                        )}
 
-                      {/* 채팅 버튼 */}
+                        <BasicButton
+                          icon="arrow-back"
+                          title="퇴장하기"
+                          color="#e67e22"
+                          onPress={() => handleLeave(v)}
+                        />
+                      </>
+                    )}
+                    {!isHost && (
                       <BasicButton
-                        icon="bubble.left.fill"
-                        title="채팅"
-                        onPress={() => {
-                          setPartyStore({ partyId: v.id });
-                          router.push({
-                            pathname: "/chatpage",
-                            params: { roomId: v.id },
-                          });
-                        }}
+                        icon="trash"
+                        title="카풀퇴장"
+                        color="#e74c3c"
+                        onPress={() => handleLeave(v)}
                       />
-                    </RowContainer>
-                  }
-                />
-              </HighlightedCard>
+                    )}
+                    <BasicButton
+                      icon="chatbubble-ellipses"
+                      title="채팅"
+                      onPress={() => {
+                        usePartyStore.setState({ partyId: v.id });
+                        router.push({ pathname: "/chatpage", params: { roomId: v.id } });
+                      }}
+                    />
+                  </RowContainer>
+                }
+              />
             );
           })}
         </DateGroup>
@@ -339,8 +257,3 @@ const DateHeader = styled.Text({
   fontSize: FontSizes.medium,
   fontWeight: "bold",
 });
-
-const LoadingIndicator = styled.ActivityIndicator.attrs({
-  size: "small",
-  color: Colors.main,
-})``;

--- a/entities/common/components/Icon_symbol.tsx
+++ b/entities/common/components/Icon_symbol.tsx
@@ -6,11 +6,15 @@ import styled from "styled-components/native";
 
 // SF Symbols -> Material Icons
 const MAPPING = {
+  "arrow-back-outline": "arrow-back",
+  "arrow-back": "arrow-back",
+  "chatbubble-ellipses": "chat",
   "house.fill": "home",
   "paperplane.fill": "send",
   "chevron.left.forwardslash.chevron.right": "code",
   "chevron.right": "chevron-right",
   "bubble.left.fill": "chat",
+  settings: "settings",
   "person.circle": "account-circle",
   "magnifyingglass.circle": "search",
   "arrow.2.circlepath.circle": "swap-vert",

--- a/entities/common/components/party_card.tsx
+++ b/entities/common/components/party_card.tsx
@@ -17,6 +17,7 @@ import { OutShadow } from "./shadows";
 type Buttons = {
   buttons: React.ReactNode;
   showTitle?: boolean;
+  isActive?: boolean; // ⭐ 활성/비활성 여부 추가
 };
 
 export default function PartyCard({
@@ -30,6 +31,7 @@ export default function PartyCard({
   comment = "",
   buttons,
   showTitle = false,
+  isActive = true, // ⭐ 기본값 true
 }: Omit<Party, "partyId"> & Buttons) {
   if (when2go === undefined) {
     return <MediumText>데이터 이상</MediumText>;
@@ -45,69 +47,97 @@ export default function PartyCard({
 
   return (
     <OutShadow borderRadius={22}>
-      <Container>
-        {showTitle && <Title>{getTitle()}</Title>}
+      <Container isActive={isActive}>
+        {showTitle && <Title isActive={isActive}>{getTitle()}</Title>}
+
         <Path>
-          <MediumText color={Colors.main}>{departure?.name}</MediumText>
-          <IconSymbol name="arrow.right" color={Colors.main} />
-          <MediumText color={Colors.main}>{destination?.name}</MediumText>
+          <MediumText isActive={isActive} color={Colors.main}>
+            {departure?.name}
+          </MediumText>
+          <IconSymbol name="arrow.right" color={isActive ? Colors.main : Colors.darkGray} />
+          <MediumText isActive={isActive} color={Colors.main}>
+            {destination?.name}
+          </MediumText>
         </Path>
+
         <Instructors>
+          {/* 일정 표시 */}
           <Instructor>
-            <IconSymbol name="clock" />
-            <MediumText>{`${
-              format(new Date(when2go), "yyyy-MM-dd") === format(new Date(), "yyyy-MM-dd")
-                ? "오늘"
-                : format(new Date(when2go), "MM.dd")
-            } / ${format(new Date(when2go), "HH:mm")} / ${
-              differenceInDays(new Date(when2go), new Date()) > 0
-                ? `${differenceInDays(new Date(when2go), new Date())}일 후`
-                : differenceInSeconds(new Date(when2go), new Date()) < 0
-                  ? "종료됨"
-                  : `${differenceInHours(new Date(when2go), new Date())}시간 ${differenceInMinutes(new Date(when2go), new Date()) % 60}분 후`
-            }`}</MediumText>
+            <IconSymbol name="clock" color={isActive ? Colors.black : Colors.darkGray} />
+            <MediumText isActive={isActive}>
+              {`${
+                format(targetDate, "yyyy-MM-dd") === format(new Date(), "yyyy-MM-dd")
+                  ? "오늘"
+                  : format(targetDate, "MM.dd")
+              } / ${format(targetDate, "HH:mm")} / ${
+                differenceInDays(targetDate, new Date()) > 0
+                  ? `${differenceInDays(targetDate, new Date())}일 후`
+                  : differenceInSeconds(targetDate, new Date()) < 0
+                    ? "종료됨"
+                    : `${differenceInHours(targetDate, new Date())}시간 ${
+                        differenceInMinutes(targetDate, new Date()) % 60
+                      }분 후`
+              }`}
+            </MediumText>
           </Instructor>
+
+          {/* 인원 표시 */}
           <Instructor>
-            <IconSymbol name="person.3" />
-            <MediumText>
+            <IconSymbol name="person.3" color={isActive ? Colors.black : Colors.darkGray} />
+            <MediumText isActive={isActive}>
               {curMembers} / {maxMembers}
             </MediumText>
-            <Instructor>
-              {estimatedFare !== undefined && estimatedFare !== null && (
-                <MediumText>
-                  <MediumText style={{ fontWeight: "bold" }}>₩</MediumText>
-                  {estimatedFare} 예상
+
+            {estimatedFare !== undefined && estimatedFare !== null && (
+              <MediumText isActive={isActive}>
+                <MediumText isActive={isActive} style={{ fontWeight: "bold" }}>
+                  ₩
                 </MediumText>
-              )}
-            </Instructor>
+                {estimatedFare} 예상
+              </MediumText>
+            )}
           </Instructor>
+
+          {/* 옵션 */}
           <Instructor>
-            <MediumText color={Colors.darkGray}>{formatOptions(options)}</MediumText>
+            <MediumText isActive={isActive} color={Colors.darkGray}>
+              {formatOptions(options)}
+            </MediumText>
           </Instructor>
-          {comment && <MediumText>{comment}</MediumText>}
+
+          {/* 코멘트 */}
+          {comment && <MediumText isActive={isActive}>{comment}</MediumText>}
         </Instructors>
+
         {buttons}
       </Container>
     </OutShadow>
   );
 }
 
-const Container = styled.View({
-  backgroundColor: "rgba(255, 255, 255, 0.5)",
+/* ============================
+      스타일 정의
+============================ */
+
+const Container = styled.View<{ isActive: boolean }>((props) => ({
+  backgroundColor: props.isActive ? "white" : "rgba(220,220,220,0.5)",
   padding: 20,
   borderRadius: 22,
-});
-const Title = styled.Text({
+  opacity: props.isActive ? 1 : 0.55, // ⭐ 비활성일 때 흐리게
+}));
+
+const Title = styled.Text<{ isActive: boolean }>((props) => ({
   fontSize: FontSizes.large,
   fontWeight: "bold",
-  color: Colors.black,
+  color: props.isActive ? Colors.black : Colors.darkGray,
   marginBottom: 10,
-});
+}));
+
 const Path = styled.View({
   display: "flex",
   flexDirection: "row",
   alignItems: "center",
-  gap: "10px",
+  gap: 10,
 });
 
 const Instructors = styled.View({
@@ -115,16 +145,18 @@ const Instructors = styled.View({
   marginHorizontal: 5,
   display: "flex",
   flexDirection: "column",
-  gap: "10px",
+  gap: 10,
 });
+
 const Instructor = styled.View({
   display: "flex",
   flexDirection: "row",
   alignItems: "center",
-  gap: "10px",
+  gap: 10,
 });
 
-const MediumText = styled.Text<{ color?: string }>((props) => ({
+const MediumText = styled.Text<{ color?: string; isActive?: boolean }>((props) => ({
   fontSize: FontSizes.medium,
   color: props.color ?? Colors.black,
+  opacity: props.isActive ? 1 : 0.5, // ⭐ 비활성 텍스트 흐리게
 }));


### PR DESCRIPTION
카풀 삭제 버튼 제거
기존에 카풀 삭제는 호스트만 사용 가능한 버튼으로 방 자체를 폭파시키는 기능을 함(방이 사라졌으니 해당 파티에 들어있는 유저들의 ui에도 사라짐) 이 버튼은 문제가 많을것으로 예상되어서 제거함

카풀 퇴장 버튼 적극활용
카풀 퇴장 버튼에 stomp, fcm 모두 unsub하는 기능과 동시에 해당 파티 ui를 제거하게 함
 -> 채팅 알림 안오는 상태가 되면서 ui가 사라져서 해당 유저에게는 완전히 제거된 카풀방이 될것임(호스트일시 다음으로 들어온 멤버가 호스트로 승격{설정변경 버튼 사용 가능}, 마지막 유저가 퇴장하기 누르면 완전히 방이 사라짐)

활성화된 카풀, 종료된 카풀 구분
지금 ui가 활성화된거랑 안된거랑 구분이 너무 안됨 눈에 띄게 구분 가능하게 변경